### PR TITLE
Add headers_mut method to RequestSettings

### DIFF
--- a/crates/fhir-sdk/src/client/request.rs
+++ b/crates/fhir-sdk/src/client/request.rs
@@ -84,6 +84,10 @@ impl RequestSettings {
 		self
 	}
 
+	pub fn headers_mut(&mut self) -> &mut HeaderMap {
+		&mut self.headers
+	}
+
 	/// Make a HTTP request using the settings. Returns the response.
 	pub(crate) async fn make_request(
 		&self,

--- a/crates/fhir-sdk/src/client/request.rs
+++ b/crates/fhir-sdk/src/client/request.rs
@@ -84,6 +84,7 @@ impl RequestSettings {
 		self
 	}
 
+	/// Provides the HeaderMap such that it can be changed directly
 	pub fn headers_mut(&mut self) -> &mut HeaderMap {
 		&mut self.headers
 	}


### PR DESCRIPTION
Is needed to make use of OpenTelemetry's `HeaderInjector` that is used to propagate baggage.